### PR TITLE
To fix the bug in Tuto_3.2

### DIFF
--- a/Tutorials/Day_3/Tuto_3.2_Parameter_estimation_for_compact_object_mergers.ipynb
+++ b/Tutorials/Day_3/Tuto_3.2_Parameter_estimation_for_compact_object_mergers.ipynb
@@ -88,8 +88,8 @@
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "from __future__ import division, print_function\n",
+    "%matplotlib inline\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "\n",


### PR DESCRIPTION
To fix the following bug:
>>>
  File "<ipython-input-2-a36fa24f80fa>", line 5    
    ^
SyntaxError: from __future__ imports must occur at the beginning of the file